### PR TITLE
Add multiflavor support to findbugs

### DIFF
--- a/src/test/groovy/com/vanniktech/code/quality/tools/CommonCodeQualityToolsTest.groovy
+++ b/src/test/groovy/com/vanniktech/code/quality/tools/CommonCodeQualityToolsTest.groovy
@@ -50,4 +50,8 @@ public abstract class CommonCodeQualityToolsTest {
 
     return false
   }
+
+  static boolean taskClasses(final Project project, final Task task, final String classes) {
+    return task.classes.dir.absolutePath.replace(project.projectDir.absolutePath, '') == classes
+  }
 }


### PR DESCRIPTION
- create per-flavor findbugs checker tasks
  with automatic classpath setup
- add a list of default android exclusions
  (borrowed from: https://github.com/ChaitanyaPramod/findbugs-android/blob/master/src/main/groovy/com/chaitanyapramod/gradle/android/findbugs/FindBugsAndroidPlugin.groovy)
- generate only one type of findbugs reports per run (prefer xml)