### PR TITLE
Fix findbugs tasks when running on Java Module with Gradle 4.*

### DIFF
--- a/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
@@ -163,7 +163,7 @@ class CodeQualityToolsPlugin implements Plugin<Project> {
 
   protected static boolean addFindbugs(final Project subProject, final Project rootProject, final CodeQualityToolsPluginExtension extension) {
     if (!shouldIgnore(subProject, extension) && extension.findbugs.enabled) {
-      final String findbugsClassesPath = isAndroidProject(subProject) ? 'build/intermediates/classes/debug/' : 'build/classes/main/'
+      final String findbugsClassesPath = isAndroidProject(subProject) ? 'build/intermediates/classes/debug/' : 'build/classes/java/main/'
 
       subProject.plugins.apply('findbugs')
 

--- a/src/test/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPluginTest.groovy
+++ b/src/test/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPluginTest.groovy
@@ -8,7 +8,7 @@ public class CodeQualityToolsPluginTest extends CommonCodeQualityToolsTest {
   @Test public void testAddFindbugsJavaDefault() {
     assert CodeQualityToolsPlugin.addFindbugs(javaProject, rootProject, new CodeQualityToolsPluginExceptionForTests())
 
-    assertFindbugs(javaProject, "/build/classes/main")
+    assertFindbugs(javaProject, "/build/classes/java/main")
   }
 
   @Test public void testAddFindbugsAndroidAppDefault() {


### PR DESCRIPTION
This will break Gradle 3.* but I'm not that eager to using them.