### PR TITLE
Fix gradle build and clean issue on Windows.

### DIFF
--- a/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
@@ -244,12 +244,15 @@ class CodeQualityToolsPlugin implements Plugin<Project> {
 
       subProject.task('ktlint', type: Exec) {
         commandLine 'java', '-cp', subProject.configurations.ktlint.join(System.getProperty('path.separator')), 'com.github.shyiko.ktlint.Main', '--reporter=checkstyle', 'src/**/*.kt'
-        def outputDirectory = new File(subProject.buildDir, "reports/ktlint/")
-        outputDirectory.mkdirs()
+        def outputDirectory = "${subProject.buildDir}reports/ktlint/"
+        def outputFile = "${outputDirectory}ktlint-checkstyle-report.xml"
 
-        def outputFile = new File(outputDirectory, "ktlint-checkstyle-report.xml")
-        standardOutput = new FileOutputStream(outputFile)
         ignoreExitValue = true
+
+        doFirst {
+          new File(outputDirectory).mkdirs()
+          standardOutput = new FileOutputStream(outputFile)
+        }
 
         doLast {
           standardOutput.close()


### PR DESCRIPTION
I am facing the following issue on my windows machine: after building the project I am unable to clean it because windows refuses to delete ktlint checkstyle report.

https://gist.github.com/anonymous/6e2b55fe13ab806880faf0fc0dd70cba

It seems that this file is being locked by plugin code.
In my fix I deleted FileOutputStream that seems to be unnecessary.
I verified it on my machine.
