### PR TITLE
Fix paths in ktlint output directory 2.0

### DIFF
--- a/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.groovy
@@ -244,8 +244,8 @@ class CodeQualityToolsPlugin implements Plugin<Project> {
 
       subProject.task('ktlint', type: Exec) {
         commandLine 'java', '-cp', subProject.configurations.ktlint.join(System.getProperty('path.separator')), 'com.github.shyiko.ktlint.Main', '--reporter=checkstyle', 'src/**/*.kt'
-        def outputDirectory = "${subProject.buildDir}/reports/ktlint/"
-        def outputFile = "${outputDirectory}ktlint-checkstyle-report.xml"
+        def outputDirectory = "${subProject.buildDir}/reports/ktlint"
+        def outputFile = "${outputDirectory}/ktlint-checkstyle-report.xml"
 
         ignoreExitValue = true
 


### PR DESCRIPTION
I am sorry that I didn’t check my last revision of previous pull request (https://github.com/vanniktech/gradle-code-quality-tools-plugin/pull/84) on windows. 
(It takes about 10 minutes to check it on my project)
When we removed “/” in outputDirectory and outputFile paths it created following issues:
1)	Ktlint reports are created in folder buildreports instead of build\reports\ktlint. And buildreports folder has empty folder ktlint.
2)	Reports has name: “ktlintktlint-checkstyle-report”
3)	It is not possible to delete or open report file
Returning back those 2 slashes in outputDirectory and outputFile fixes all problems above.