### PR TITLE
Implement breaking changes for Detekt 1.0.0.RC10

### DIFF
--- a/src/main/kotlin/com/vanniktech/code/quality/tools/KtlintExtension.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/KtlintExtension.kt
@@ -2,7 +2,7 @@ package com.vanniktech.code.quality.tools
 
 open class KtlintExtension {
   /**
-   * ability to enable or disable only ktlint for every subproject that is not ignored
+   * ability to enable or disable only ktlint for every subproject that is not ignored.
    * @since 0.5.0
    */
   var enabled: Boolean = true

--- a/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
+++ b/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
@@ -32,6 +32,13 @@ class CodeQualityToolsPluginDetektTest {
         .succeeds()
   }
 
+  @Test fun successBreakingReportChangeRC10() {
+    Roboter(testProjectDir, version = "1.0.0-RC10")
+        .withConfiguration("failFast: true")
+        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .succeeds()
+  }
+
   @Test fun noSrcFolder() {
     Roboter(testProjectDir)
         .withConfiguration("failFast: true")


### PR DESCRIPTION
This will still fail since the version hasn't been published yet.