### PR TITLE
Kotlin: Treat warnings as errors by default.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
   api 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.14'
 
   compileOnly "com.android.tools.build:gradle:$androidGradlePluginVersion"
+  compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
   testImplementation "com.android.tools.build:gradle:$androidGradlePluginVersion"
   testImplementation 'junit:junit:4.12'

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
@@ -23,6 +23,7 @@ import org.gradle.api.plugins.quality.PmdExtension
 import org.gradle.api.plugins.quality.PmdPlugin
 import org.gradle.language.base.plugins.LifecycleBasePlugin.ASSEMBLE_TASK_NAME
 import org.gradle.language.base.plugins.LifecycleBasePlugin.CHECK_TASK_NAME
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 
 const val GROUP_VERIFICATION = "verification"
@@ -50,6 +51,7 @@ class CodeQualityToolsPlugin : Plugin<Project> {
     project.addPmd(rootProject, extension)
     project.addCheckstyle(rootProject, extension)
     project.addKtlint(rootProject, extension)
+    project.addKotlin(extension)
     project.addCpd(extension)
     project.addDetekt(rootProject, extension)
     project.addErrorProne(extension)
@@ -272,6 +274,20 @@ fun Project.addFindbugs(rootProject: Project, extension: CodeQualityToolsPluginE
       tasks.named(CHECK_TASK_NAME).configure { it.dependsOn("lint") }
       return true
     }
+  }
+
+  return false
+}
+
+fun Project.addKotlin(extension: CodeQualityToolsPluginExtension): Boolean {
+  val isNotIgnored = !shouldIgnore(extension)
+  val isKotlinProject = isKotlinProject()
+
+  if (isNotIgnored && isKotlinProject) {
+    project.tasks.withType(KotlinCompile::class.java) {
+      it.kotlinOptions.allWarningsAsErrors = extension.kotlin.allWarningsAsErrors
+    }
+    return true
   }
 
   return false

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginExtension.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginExtension.kt
@@ -60,4 +60,7 @@ open class CodeQualityToolsPluginExtension @Inject constructor(
 
   val errorProne = objectFactory.newInstance(ErrorProneExtension::class.java)
   fun errorProne(action: Action<in ErrorProneExtension>) = action.execute(errorProne)
+
+  val kotlin = objectFactory.newInstance(KotlinExtension::class.java)
+  fun kotlin(action: Action<in KotlinExtension>) = action.execute(kotlin)
 }

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/KotlinExtension.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/KotlinExtension.kt
@@ -1,0 +1,9 @@
+package com.vanniktech.code.quality.tools
+
+open class KotlinExtension {
+  /**
+   * Ability to treat all Kotlin compiler warnings as errors
+   * @since 0.17.0
+   */
+  var allWarningsAsErrors: Boolean = true
+}

--- a/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
+++ b/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
@@ -14,42 +14,42 @@ class CodeQualityToolsPluginDetektTest {
   @Test fun success() {
     Roboter(testProjectDir)
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun successBreakingReportChangeRC9() {
     Roboter(testProjectDir, version = "1.0.0.RC9")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun successBreakingReportChangeRC92() {
     Roboter(testProjectDir, version = "1.0.0.RC9.2")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun successBreakingReportChangeRC10() {
     Roboter(testProjectDir, version = "1.0.0-RC10")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun worksWithRC11() {
     Roboter(testProjectDir, version = "1.0.0-RC11")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun worksWithRC12() {
     Roboter(testProjectDir, version = "1.0.0-RC12")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
@@ -62,15 +62,15 @@ class CodeQualityToolsPluginDetektTest {
   @Test fun differentConfigFile() {
     Roboter(testProjectDir, config = "code_quality_tools/config-detekt.yml")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
         .succeeds()
   }
 
   @Test fun fails() {
     Roboter(testProjectDir)
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
-        .fails()
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
+        .fails(containsMessage = "NewLineAtEndOfFile - [Foo.kt]")
   }
 
   @Test fun ignoresFileInBuildDirectory() {
@@ -84,21 +84,21 @@ class CodeQualityToolsPluginDetektTest {
     Roboter(testProjectDir)
         .withConfiguration("failFast: true")
         .withKotlinFile("build.gradle.kts", "fun foo() = Unit")
-        .fails()
+        .fails(containsMessage = "NewLineAtEndOfFile - [build.gradle.kts]")
   }
 
   @Test fun disabled() {
     Roboter(testProjectDir, enabled = false)
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
         .doesNothing()
   }
 
   @Test fun creatingInitialBaselineFails() {
     Roboter(testProjectDir, baselineFileName = "detekt-baseline.xml")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
-        .fails()
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
+        .fails(containsMessage = "NewLineAtEndOfFile - [Foo.kt]")
         .baseLineContains("<ID>NewLineAtEndOfFile:Foo.kt\$.Foo.kt</ID>")
   }
 
@@ -113,14 +113,14 @@ class CodeQualityToolsPluginDetektTest {
                 <ID>NewLineAtEndOfFile:Foo.kt$.Foo.kt</ID>
               </Whitelist>
             </SmellBaseline>""".trimIndent())
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
         .succeeds()
   }
 
   @Test fun mayBeConstSucceedsWithReleaseCandidate7() {
     Roboter(testProjectDir, version = "1.0.0.RC7")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", """
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", """
             |const val TEST = "test"
             |val TEST2 = "test" + TEST
             |""".trimMargin())
@@ -131,18 +131,18 @@ class CodeQualityToolsPluginDetektTest {
     // RC7-2 fixed this - https://github.com/arturbosch/detekt/pull/930
     Roboter(testProjectDir, version = "1.0.0.RC7-2")
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", """
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", """
             |const val TEST = "test"
             |val TEST2 = "test" + TEST
             |""".trimMargin())
-        .fails()
+        .fails(containsMessage = "MayBeConst - [TEST2] at")
   }
 
   @Test fun checkTaskRunsDetekt() {
     Roboter(testProjectDir)
         .withConfiguration("failFast: true")
-        .withKotlinFile("src/main/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
-        .fails(taskToRun = "check", taskToCheck = "detektCheck")
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo() = Unit")
+        .fails(taskToRun = "check", taskToCheck = "detektCheck", containsMessage = "NewLineAtEndOfFile - [Foo.kt] at")
   }
 
   class Roboter(
@@ -196,8 +196,10 @@ class CodeQualityToolsPluginDetektTest {
       assertReportsExist()
     }
 
-    fun fails(taskToRun: String = "detektCheck", taskToCheck: String = taskToRun) = apply {
-      assertThat(run(taskToRun).buildAndFail().task(":$taskToCheck")?.outcome).isEqualTo(TaskOutcome.FAILED)
+    fun fails(taskToRun: String = "detektCheck", taskToCheck: String = taskToRun, containsMessage: String) = apply {
+      val buildResult = run(taskToRun).buildAndFail()
+      assertThat(buildResult.task(":$taskToCheck")?.outcome).isEqualTo(TaskOutcome.FAILED)
+      assertThat(buildResult.output).contains(containsMessage)
       assertReportsExist()
     }
 

--- a/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginKotlinTest.kt
+++ b/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginKotlinTest.kt
@@ -1,0 +1,73 @@
+package com.vanniktech.code.quality.tools
+
+import org.assertj.core.api.Java6Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CodeQualityToolsPluginKotlinTest {
+  @get:Rule val testProjectDir = TemporaryFolder()
+
+  @Test fun success() {
+    Roboter(testProjectDir)
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", "fun foo(param: Int) = param * param\n")
+        .succeeds()
+  }
+
+  @Test fun fails() {
+    Roboter(testProjectDir)
+        .withKotlinFile("src/main/kotlin/com/vanniktech/test/Foo.kt", """
+            @Deprecated("Don't use this") fun bar() = { }
+            fun foo() = bar()
+            """.trimIndent())
+        .fails(containsMessage = "bar(): () -> Unit' is deprecated. Don't use this")
+  }
+
+  class Roboter(
+    private val directory: TemporaryFolder
+  ) {
+    init {
+      directory.newFile("build.gradle").writeText("""
+          |plugins {
+          |  id "kotlin"
+          |  id "com.vanniktech.code.quality.tools"
+          |}
+          |
+          |codeQualityTools {
+          |  ktlint.enabled = false
+          |  detekt.enabled = false
+          |  checkstyle.enabled = false
+          |  pmd.enabled = false
+          |  findbugs.enabled = false
+          |  cpd.enabled = false
+          |  errorProne.enabled = false
+          |}
+          |
+          |repositories {
+          |  jcenter()
+          |}
+          |""".trimMargin())
+    }
+
+    fun withKotlinFile(path: String, content: String) = write(path, content)
+
+    private fun write(path: String, content: String) = apply {
+      directory.newFolder(*path.split("/").dropLast(1).toTypedArray())
+      directory.newFile(path).writeText(content)
+    }
+
+    fun succeeds(taskToRun: String = "compileKotlin") = apply {
+      assertThat(run(taskToRun).build().task(":$taskToRun")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    fun fails(taskToRun: String = "compileKotlin", taskToCheck: String = taskToRun, containsMessage: String) = apply {
+      val buildResult = run(taskToRun).buildAndFail()
+      assertThat(buildResult.task(":$taskToCheck")?.outcome).isEqualTo(TaskOutcome.FAILED)
+      assertThat(buildResult.output).contains(containsMessage)
+    }
+
+    private fun run(taskToRun: String) = GradleRunner.create().withPluginClasspath().withProjectDir(directory.root).withArguments(taskToRun)
+  }
+}


### PR DESCRIPTION
Fixes #171