### PR TITLE
Detekt: Add --build-upon-default-config parameter support

### DIFF
--- a/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
@@ -311,6 +311,7 @@ fun Project.addDetekt(rootProject: Project, extension: CodeQualityToolsPluginExt
 
     tasks.register("detektCheck", DetektCheckTask::class.java) { task ->
       task.failFast = extension.detekt.failFast
+      task.buildUponDefaultConfig = extension.detekt.buildUponDefaultConfig
       task.version = extension.detekt.toolVersion
       task.outputDirectory = File(buildDir, "reports/detekt/")
       task.configFile = rootProject.file(extension.detekt.config)

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/DetektCheckTask.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/DetektCheckTask.kt
@@ -17,6 +17,7 @@ import java.io.File
 
 @CacheableTask open class DetektCheckTask : DefaultTask() {
   @Input var failFast: Boolean = true
+  @Input var buildUponDefaultConfig: Boolean = false
   @Input lateinit var version: String
 
   // Ideally this would be an optional input file - https://github.com/gradle/gradle/issues/2016
@@ -68,6 +69,10 @@ import java.io.File
 
       if (failFast) {
         task.args("--fail-fast")
+      }
+
+      if (buildUponDefaultConfig) {
+        task.args("--build-upon-default-config")
       }
 
       if (shouldCreateBaseLine) {

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/DetektExtension.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/DetektExtension.kt
@@ -27,4 +27,10 @@ open class DetektExtension {
    * @since 0.18.0
    */
   var failFast: Boolean = true
+
+  /**
+   * Whether to use preconfigured defaults. Allows provided configurations to override them.
+   * @since 0.19.0
+   */
+  var buildUponDefaultConfig: Boolean = false
 }

--- a/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
+++ b/src/test/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPluginDetektTest.kt
@@ -34,6 +34,13 @@ class CodeQualityToolsPluginDetektTest {
         .succeeds()
   }
 
+  @Test fun defaultConfigFile() {
+    Roboter(testProjectDir, buildUponDefaultConfig = true)
+      .withConfiguration("failFast: true")
+      .withKotlinFile(testPath, testCode)
+      .succeeds()
+  }
+
   @Test fun differentConfigFile() {
     Roboter(testProjectDir, config = "code_quality_tools/config-detekt.yml")
         .withConfiguration("failFast: true")
@@ -104,7 +111,8 @@ class CodeQualityToolsPluginDetektTest {
     private val config: String = "code_quality_tools/detekt.yml",
     enabled: Boolean = true,
     version: String = "1.0.0",
-    private val baselineFileName: String? = null
+    private val baselineFileName: String? = null,
+    buildUponDefaultConfig: Boolean = false
   ) {
     init {
       directory.newFile("build.gradle").writeText("""
@@ -115,6 +123,7 @@ class CodeQualityToolsPluginDetektTest {
           |
           |codeQualityTools {
           |  detekt {
+          |    buildUponDefaultConfig = $buildUponDefaultConfig
           |    config = "$config"
           |    enabled = $enabled
           |    toolVersion = "$version"


### PR DESCRIPTION
Extended DetektExtension to make Detekt use its default configuration according to:
https://arturbosch.github.io/detekt/cli.html 