### PR TITLE
Detekt: add ability to specify input directory

### DIFF
--- a/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/CodeQualityToolsPlugin.kt
@@ -80,7 +80,8 @@ fun hasLintPlugin(): Boolean {
   }
 }
 
-fun Project.kotlinFiles() = fileTree(mapOf("dir" to ".", "exclude" to "**/build/**", "includes" to listOf("**/*.kt", "**/*.kts")))
+fun Project.kotlinFiles(baseDir: String = ".") =
+  fileTree(mapOf("dir" to baseDir, "exclude" to "**/build/**", "includes" to listOf("**/*.kt", "**/*.kts")))
 
 fun Project.editorconfigFile() = fileTree(mapOf("dir" to ".", "include" to ".editorconfig"))
 
@@ -321,7 +322,8 @@ fun Project.addDetekt(rootProject: Project, extension: CodeQualityToolsPluginExt
       task.version = extension.detekt.toolVersion
       task.outputDirectory = File(buildDir, "reports/detekt/")
       task.configFile = rootProject.file(extension.detekt.config)
-      task.inputs.files(kotlinFiles())
+      task.input = extension.detekt.input
+      task.inputs.files(kotlinFiles(baseDir = extension.detekt.input))
 
       task.inputs.property("baseline-file-exists", false)
 

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/DetektCheckTask.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/DetektCheckTask.kt
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.TaskExecutionException
 import java.io.File
 
 @CacheableTask open class DetektCheckTask : DefaultTask() {
+  @Input var input: String = "."
   @Input var failFast: Boolean = true
   @Input var buildUponDefaultConfig: Boolean = false
   @Input var parallel: Boolean = false
@@ -57,7 +58,7 @@ import java.io.File
       task.main = "io.gitlab.arturbosch.detekt.cli.Main"
       task.classpath = configuration
       task.args(
-          "--input", project.file("."),
+          "--input", project.file(input),
           reportKey, reportValue
       )
 

--- a/src/main/kotlin/com/vanniktech/code/quality/tools/DetektExtension.kt
+++ b/src/main/kotlin/com/vanniktech/code/quality/tools/DetektExtension.kt
@@ -40,4 +40,12 @@ open class DetektExtension {
    * @since 0.19.0
    */
   var parallel: Boolean = false
+
+  /**
+   * Directories to look for source files.
+   * Defaults to current directory.
+   *
+   * @since 0.21.0
+   */
+  var input: String = "."
 }


### PR DESCRIPTION
This patch allows to customize detekt's --input argument similar to 
https://detekt.github.io/detekt/gradle.html#groovy-dsl-3
https://detekt.github.io/detekt/cli.html#use-the-cli .